### PR TITLE
修正：日付出力処理の部分で日付形式の設定が考慮されない

### DIFF
--- a/inc/pluggable.php
+++ b/inc/pluggable.php
@@ -116,7 +116,7 @@ if ( ! function_exists( 'ark_the__thumbnail' ) ) {
 
 /**
  * 投稿の日付データを出力 (アーカイブと投稿ページで使用)
- * date: DateTime object
+ * date: タイムスタンプ
  */
 if ( ! function_exists( 'ark_the__postdate' ) ) {
 	function ark_the__postdate( $date = null, $type = 'posted' ) {
@@ -126,9 +126,9 @@ if ( ! function_exists( 'ark_the__postdate' ) ) {
 		$date_format = get_option( 'date_format' );
 		$type_class  = "-{$type}";
 
-		$return = '<time class="c-postTimes__item u-flex--aic ' . esc_attr( $type_class ) . '" datetime="' . esc_attr( $date->format( 'Y-m-d' ) ) . '">' .
+		$return = '<time class="c-postTimes__item u-flex--aic ' . esc_attr( $type_class ) . '" datetime="' . wp_date( 'Y-m-d', $date ) . '">' .
 			Arkhe::get_svg( $type, array( 'class' => 'c-postMetas__icon' ) ) .
-			esc_html( $date->format( $date_format ) ) .
+			esc_html( wp_date( $date_format, $date ) ) .
 		'</time>';
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/template-parts/post_list/item/meta/times.php
+++ b/template-parts/post_list/item/meta/times.php
@@ -6,9 +6,9 @@
 $date     = isset( $args['date'] ) ? $args['date'] : null;
 $modified = isset( $args['modified'] ) ? $args['modified'] : null;
 
-// まだ文字列の場合はDateTime化 ( is_stringチェックは後方互換用 )
-if ( is_string( $date ) ) $date         = new DateTime( $date );
-if ( is_string( $modified ) ) $modified = new DateTime( $modified );
+// まだ文字列の場合はタイムスタンプ化 ( is_stringチェックは後方互換用 )
+if ( is_string( $date ) ) $date         = strtotime( $date );
+if ( is_string( $modified ) ) $modified = strtotime( $modified );
 
 // 両方表示する設定の場合、更新日は公開日より遅い場合だけ表示
 if ( $date && $modified ) {

--- a/template-parts/single/head/meta.php
+++ b/template-parts/single/head/meta.php
@@ -3,8 +3,8 @@
  * 投稿メタ（head）
  */
 $post_data = get_post();
-$date      = new DateTime( $post_data->post_date );
-$modified  = new DateTime( $post_data->post_modified );
+$date      = strtotime( $post_data->post_date );
+$modified  = strtotime( $post_data->post_modified );
 $author_id = $post_data->post_author;
 
 $show_posted   = Arkhe::get_setting( 'show_entry_posted' );


### PR DESCRIPTION
## 概要

各パーツの日付の出力部分について、WordPressの日付形式が反映されるように修正しました。

## 原因・対応内容

以下、SWELLのPRの原因・対応内容と同じとなります。
https://github.com/loos/SWELL/pull/251