### PR TITLE
fix: 検索ブロックのボタンスタイルが WP7.0 で変わる問題を修正 (#163)

### DIFF
--- a/src/scss/post_content/common/blocks/_core-search.scss
+++ b/src/scss/post_content/common/blocks/_core-search.scss
@@ -9,8 +9,12 @@
 	}
 
 
+	// WP7.0以降、デフォルトtheme.jsonの elements.button スタイルが検索ボタンにも
+	// 適用されるため、padding / color を明示指定して上書きする（コアの :where() 指定は詳細度0）。
 	.wp-block-search__button {
 		// font-size: 14px;
+		padding: 6px 10px;
+		color: var(--ark-color--text);
 		line-height: 1.5;
 		background: var(--ark-color--gray);
 		border-radius: 2px;
@@ -65,6 +69,8 @@
 	}
 
 	.wp-block-search__button {
+		// WP7.0のtheme.json適用対策（padding を明示）
+		padding: 4px 8px;
 		background: none;
 		box-shadow: none;
 	}


### PR DESCRIPTION
## 概要

WP 7.0 でデフォルト `theme.json` のスタイルがクラシックテーマにも適用されるようになり、検索ブロックのボタンスタイル（サイズ・色）が変わってしまう問題を修正します。

Closes #163

## 原因

WP コアの検索ブロック `style.css` は、ボタンの `padding` を `:where()` でラップして指定しているため**詳細度が 0** です。

```css
:where(.wp-block-search__button){ padding:6px 10px; }
:where(.wp-block-search__button-inside ...) :where(.wp-block-search__button){ padding:4px 8px; }
```

WP 7.0 でデフォルト `theme.json` の `elements.button` がクラシックテーマにも適用されるようになり、その `padding`（詳細度 `0,1,0`）がコアの `:where()` 指定（詳細度 `0`）を上書きします。Arkhe の `_core-search.scss` はボタンに `padding` / `color` を明示していなかったため、WP 7.0 のデフォルト値が入り込みボタンが大きくなっていました。

## 修正内容

`src/scss/post_content/common/blocks/_core-search.scss` のボタンルールに `padding` / `color` を明示指定しました。Arkhe のルールは `.wp-block-search .wp-block-search__button`（詳細度 `0,2,0`）で `theme.json`（`0,1,0`）より高いため、明示するだけで上書きできます。詳細度の変更は不要でした。

- 通常ボタン: `padding: 6px 10px` / `color: var(--ark-color--text)` を追加（コアの従来値を維持）
- `button-inside` 内のボタン: `padding: 4px 8px` を追加（コアの従来値を維持）

`_core-search.scss` は `common` 配下のため、フロント（`main.css`）・エディター（`editor.css`）の両方に反映されます。`npm run build:css` でビルドが通ること、両 CSS に詳細度 `0,2,0` で出力されることを確認済みです。
