### PR TITLE
fix: カレンダーブロックがエディターで全幅になる問題を修正 (#164)

### DIFF
--- a/src/scss/post_content/gutenberg/core-blocks/_widget-blockss.scss
+++ b/src/scss/post_content/gutenberg/core-blocks/_widget-blockss.scss
@@ -140,8 +140,22 @@ ul.wp-block-categories__list {
 
 
 // カレンダー
+// WP7.0〜：HtmlRenderer 化（gutenberg#74271）でブロックラッパー自身が
+// .wp-block-calendar になり、data-type / data-align も同じ要素に付くようになった。
+// _calendar.scss の max-width がエディターのブロック幅指定に上書きされるため、
+// 詳細度を上げてここで再指定する。
 [data-type="core/calendar"].wp-block-calendar {
 	border: none;
+
+	// 通常幅（_calendar.scss の max-width: 400px に合わせる）
+	&:where(:not([data-align="wide"], [data-align="full"])) {
+		max-width: 400px;
+	}
+
+	// 幅広・全幅は幅制限を解除
+	&:where([data-align="wide"], [data-align="full"]) {
+		max-width: unset;
+	}
 }
 
 
@@ -164,14 +178,4 @@ ul.wp-block-categories__list {
 	}
 
 
-}
-
-:where([data-align="full"],[data-align="wide"]) > .wp-block-calendar {
-	max-width: unset;
-}
-
-:where([data-align="wide"]) > .wp-block-calendar .wp-block-calendar.alignwide {
-	left: 0;
-	// 内部でレンダリングされた　.wp-block-calendar　があるのでそっちは広がらないようにする
-	width: 100%;
 }


### PR DESCRIPTION
## 概要

WordPress 7.0 のエディターで、カレンダーブロックが `max-width: 400px` を無視して全幅（100%）表示される問題を修正します。

Closes #164

## 原因

Gutenberg PR [WordPress/gutenberg#74271](https://github.com/WordPress/gutenberg/pull/74271) により、カレンダーブロックのエディター描画が `ServerSideRender` から `useServerSideRender` + `HtmlRenderer` へ移行しました。

これにより、これまで入れ子になっていた `.wp-block-calendar` が解消され、**ブロックラッパー自身が `.wp-block-calendar`（`data-type` / `data-align` も同一要素）**になりました。

その結果、`object/widget/_calendar.scss` の `max-width: 400px`（`.wp-block-calendar:where(...)` = 詳細度 0,1,0）が、エディターのブロック幅指定に上書きされるようになりました。

## 修正内容

エディター用 SCSS `_widget-blockss.scss` のカレンダー関連ルールを新しい DOM 構造に合わせて整理しました。

- `[data-type="core/calendar"].wp-block-calendar`（詳細度 0,2,0）で `max-width` を再指定
  - 通常幅: `max-width: 400px`（`_calendar.scss` に合わせる）
  - 幅広・全幅: `max-width: unset`
- 入れ子構造（旧 `ServerSideRender`）を前提にしていた `:where([data-align]) > .wp-block-calendar ...` の旧ルールを削除（新構造ではマッチしないため）

## 影響範囲

- エディター用スタイル（`dist/css/editor.css`）のみ。フロント表示への影響なし。
- PHP 変更なし。

## 確認

- `npm run build:css` でビルドが通ることを確認。
- コンパイル後の `editor.css` に詳細度 0,2,0 のルールが出力されることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
